### PR TITLE
MN-127: move long and nightly CI test scripts to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,13 @@ FUNCTEST_COUNT ?= 1
 TESTED_PACKAGES ?= $(shell go list ${ALL_PACKAGES})
 COVERPROFILE ?= coverage.txt
 TEST_ARGS ?= -timeout 1200s
+TEST_ARGS_NIGHTLY ?= -timeout 1000m
 BUILD_TAGS ?=
+LONG_TESTS_SCRIPT_PATH = ./scripts/dev/run-tests-with-repeat.sh
 
 CI_GOMAXPROCS ?= 8
 CI_TEST_ARGS ?= -p 4
+CI_LONG_TIMEOUT ?= "1*60*60" # one hour
 
 BUILD_NUMBER := $(TRAVIS_BUILD_NUMBER)
 # skip git parsing commands if no git
@@ -163,6 +166,15 @@ ci-test-unit: ## run unit tests 10 times and -race flag, redirects json output t
 	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1 \
 		$(GOTEST) $(CI_TEST_ARGS) $(TEST_ARGS) -json -v $(ALL_PACKAGES) -race -count 10
 
+.PHONY: ci-test-unit-long
+ci-test-unit-long: ## run unit tests 10 times and -race flag, repeat until temeout exceeded
+	TESTS_TIMEOUT=$(CI_LONG_TIMEOUT) $(LONG_TESTS_SCRIPT_PATH) "ci-test-unit"
+
+.PHONY: ci-test-unit-nightly
+ci-test-unit-nightly: ## run unit tests 800 times and -race flag, repeat until temeout exceeded
+	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1 \
+         $(GOTEST) $(TEST_ARGS_NIGHTLY) -json -v -failfast -p 10 -race -count 800 $(ALL_PACKAGES)
+
 .PHONY: ci-test-slow
 ci-test-slow: ## run slow tests just once, redirects json output to file (CI)
 	GOMAXPROCS=$(CI_GOMAXPROCS) CGO_ENABLED=1 \
@@ -175,12 +187,20 @@ ci-test-slow-long: ## run slow tests with race and count
 	TEST_COUNT=50 \
 		$(MAKE) ci-test-slow
 
+.PHONY: ci-test-slow-long-repeat
+ci-test-slow-long-repeat: ## run slow tests with race and count, repeat until temeout exceeded
+	TESTS_TIMEOUT=$(CI_LONG_TIMEOUT) $(LONG_TESTS_SCRIPT_PATH) "ci-test-slow-long"
+
 .PHONY: ci-test-slow-nightly
 ci-test-slow-nightly: ## run slow tests with race and count (nightly run)
 	CI_TEST_ARGS=" -race " \
 	TEST_ARGS=" -timeout 480m  " \
 	TEST_COUNT=80 \
 		$(MAKE) ci-test-slow
+
+.PHONY: ci-test-slow-nightly-repeat
+ci-test-slow-nightly-repeat: ## run slow tests with race and count (nightly run), repeat until temeout exceeded
+	TESTS_TIMEOUT=$(CI_LONG_TIMEOUT) $(LONG_TESTS_SCRIPT_PATH) "ci-test-slow-nightly"
 
 .PHONY: ci-test-func-base
 ci-test-func-base: ## run functest, redirects json output to file (CI)

--- a/scripts/dev/run-tests-with-repeat.sh
+++ b/scripts/dev/run-tests-with-repeat.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -u
+
+# pass make target(s) as arguments when running the script
+[[ "$#" == 0 ]] && return 1
+
+exitcode=0
+end=$((SECONDS+TESTS_TIMEOUT))
+while [ $SECONDS -lt $end ]; do
+  make $@ || exitcode=${exitcode}+1
+done
+
+exit ${exitcode}


### PR DESCRIPTION
Scripts used in long and nightly TeamCity configurations added as a part of Makefile

