### PR TITLE
Fix a broken code piece formatting in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,13 @@ This is if you're already using a specific version of the tools via a go@ packag
 
 When the pulse watcher says `INSOLAR STATE: READY`, you can run a benchmark in another terminal tab/window:
 
-     ```
-     bin/benchmark -c=4 -r=25 -k=.artifacts/launchnet/configs/
-     ```
 
-     Options:
-     * `-k`: Path to the root user's key pair.
-     * `-c`: Number of concurrent threads in which requests are sent.
-     * `-r`: Number of transfer requests to be sent in each thread.
+   ```bin/benchmark -c=4 -r=25 -k=.artifacts/launchnet/configs/```
+
+   Options:
+   * `-k`: Path to the root user's key pair.
+   * `-c`: Number of concurrent threads in which requests are sent.
+   * `-r`: Number of transfer requests to be sent in each thread.
      
 #### Functional tests
 


### PR DESCRIPTION
Bugfix

**- What I did**
Enabled formatting for a code piece

**- How I did it**
Changed formatting to fix it

**- How to verify it**

Compare the existing readme and my fix

**- Description for the changelog**
<!--
This piece had broken formatting and showed formatting symbols:

bin/benchmark -c=4 -r=25 -k=.artifacts/launchnet/configs/

Options:

-k: Path to the root user's key pair.
-c: Number of concurrent threads in which requests are sent.
-r: Number of transfer requests to be sent in each thread.
-->
