### PR TITLE
MN-636: add method `account.transferToDeposit`

### DIFF
--- a/application/api/spec/api-exported-internal.yaml
+++ b/application/api/spec/api-exported-internal.yaml
@@ -1502,6 +1502,114 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/response-success'
                   - $ref: '#/components/schemas/response-signedRequestError'
+  '/admin-api/rpc#account.transferToDeposit':
+    post:
+      summary: account.transferToDeposit
+      description: >
+        Transfers XNS coin fractions from a member's current account to the
+        deposit of another member.
+
+
+        To invoke this method, specify the following parameters:
+
+
+        * in `params`, `reference` to the sender's member object;
+
+        * in `callParams`:
+          * `toDepositName`—name of the receiver's deposit to send the funs to;
+          * `amount`—amount of XNS coin fractions to send;
+          * `toMemberReference`—reference to the receiver's member object.
+      operationId: account.transferToDeposit
+      tags:
+        - Member
+      parameters:
+        - $ref: '#/components/parameters/digestHeader'
+        - $ref: '#/components/parameters/signatureHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/request-contractCall'
+                - type: object
+                  required:
+                    - params
+                  properties:
+                    params:
+                      required:
+                        - callParams
+                        - reference
+                        - publicKey
+                      properties:
+                        callSite:
+                          enum:
+                            - account.transferToDeposit
+                        callParams:
+                          description: Parameters of the contract's internal method.
+                          required:
+                            - toDepositName
+                            - toMemberReference
+                            - amount
+                          properties:
+                            toDepositName:
+                              type: string
+                              description: Deposit name. Used for deposit identification.
+                              example: genesis_deposit2
+                            toMemberReference:
+                              allOf:
+                                - $ref: '#/components/schemas/reference'
+                                - description: Reference to the receiver's member object.
+                                  example: >-
+                                    insolar:1GlDeBOnc7Ar5N34ShBdkx_SAVOfnZJKUCoQMi0_OcvE
+                            amount:
+                              type: string
+                              description: >
+                                Amount of XNS coin fractions to transfer—a whole
+                                number. The smallest fraction of XNS is
+                                `1/10^10`. To specify the amount in fractions,
+                                multiply XNS by `10^10`. For example: `0.1 XNS =
+                                0.1 * 10^10 = 1000000000`.
+                              example: '1000000000'
+                              pattern: '^[1-9][0-9]*$'
+                              minLength: 1
+                              maxLength: 20
+                        reference:
+                          allOf:
+                            - $ref: '#/components/schemas/reference'
+                            - description: >-
+                                Reference to your `member` object. Used for
+                                identification.
+                              example: >-
+                                insolar:1GlDeBOnc7Ar5N34ShBdkx_SAVOfnZJKUCoQMi0_OcvE
+                        publicKey:
+                          type: string
+                          pattern: >-
+                            ^\s*(-+BEGIN[^-]+-+\s+[a-zA-Z0-9+\/=
+                            \n]+-+END[^-]+-+|[a-zA-Z0-9+\/= \n]+)\s*$
+                          description: >
+                            Public key of your `member` object. Used to check
+                            the `<signatureString>` created by the paired
+                            private key. Format: a [PEM
+                            key](https://tools.ietf.org/html/rfc1421) in a
+                            Base64 string.
+                          example: >-
+                            -----BEGIN PUBLIC KEY-----
+
+                            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMSbA4KvO/jlwY+8WFDEdwhCLlsEC
+
+                            F3/GYvu9iTWHwCctx1wTbGGjNLY03EjXyYxaf8coNbSbZeu+jXcWeMHG0A==
+
+                            -----END PUBLIC KEY-----
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/response-success'
+                  - $ref: '#/components/schemas/response-signedRequestError'
   '/admin-api/rpc#deposit.createFund':
     post:
       summary: deposit.createFund
@@ -1571,6 +1679,107 @@ paths:
                             Public key of the `migrationAdminMember` object.
                             Used to check the `<signatureString>` created by the
                             paired private key. Format: a [PEM
+                            key](https://tools.ietf.org/html/rfc1421) in a
+                            Base64 string.
+                          example: >-
+                            -----BEGIN PUBLIC KEY-----
+
+                            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMSbA4KvO/jlwY+8WFDEdwhCLlsEC
+
+                            F3/GYvu9iTWHwCctx1wTbGGjNLY03EjXyYxaf8coNbSbZeu+jXcWeMHG0A==
+
+                            -----END PUBLIC KEY-----
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/response-success'
+                  - $ref: '#/components/schemas/response-signedRequestError'
+  '/admin-api/rpc#deposit.transferToDeposit':
+    post:
+      summary: deposit.transferToDeposit
+      description: >
+        Transfer coins between specified deposits.
+
+
+        To invoke this method, specify the following parameters:
+
+
+        * in `params`, `reference` to the sender's member object;
+
+        * in `callParams`: `fromDepositName`—name of the sender's deposit to
+        withdraw the funds from;
+          * `toDepositName`—name of the receiver's deposit to send the funds to;
+          * `toMemberReference`—reference to the receiver's member object.
+      operationId: deposit.transferToDeposit
+      tags:
+        - Member
+      parameters:
+        - $ref: '#/components/parameters/digestHeader'
+        - $ref: '#/components/parameters/signatureHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/request-contractCall'
+                - type: object
+                  required:
+                    - params
+                  properties:
+                    params:
+                      required:
+                        - callParams
+                        - reference
+                        - publicKey
+                      properties:
+                        callSite:
+                          enum:
+                            - deposit.transferToDeposit
+                        callParams:
+                          description: Parameters of the contract's internal method.
+                          required:
+                            - fromDepositName
+                            - toDepositName
+                            - toMemberReference
+                          properties:
+                            fromDepositName:
+                              type: string
+                              description: >-
+                                Deposit name or Ethereum transaction's hash.
+                                Used for deposit identification.
+                              example: genesis_deposit
+                            toDepositName:
+                              type: string
+                              description: Deposit name. Used for deposit identification.
+                              example: genesis_deposit2
+                            toMemberReference:
+                              allOf:
+                                - $ref: '#/components/schemas/reference'
+                                - description: Reference to the receiver's member object.
+                                  example: >-
+                                    insolar:1GlDeBOnc7Ar5N34ShBdkx_SAVOfnZJKUCoQMi0_OcvE
+                        reference:
+                          allOf:
+                            - $ref: '#/components/schemas/reference'
+                            - description: >-
+                                Reference to your `member` object. Used for
+                                identification.
+                              example: >-
+                                insolar:1GlDeBOnc7Ar5N34ShBdkx_SAVOfnZJKUCoQMi0_OcvE
+                        publicKey:
+                          type: string
+                          pattern: >-
+                            ^\s*(-+BEGIN[^-]+-+\s+[a-zA-Z0-9+\/=
+                            \n]+-+END[^-]+-+|[a-zA-Z0-9+\/= \n]+)\s*$
+                          description: >
+                            Public key of your `member` object. Used to check
+                            the `<signatureString>` created by the paired
+                            private key. Format: a [PEM
                             key](https://tools.ietf.org/html/rfc1421) in a
                             Base64 string.
                           example: >-

--- a/application/builtin/contract/account/account.go
+++ b/application/builtin/contract/account/account.go
@@ -141,8 +141,8 @@ func (a *Account) IncreaseBalance(amountStr string) error {
 	return nil
 }
 
-// TransferToDeposit transfers money to given member deposit.
-func (a *Account) TransferToDeposit(
+// ReallocateToDeposit transfers money to given member deposit.
+func (a *Account) ReallocateToDeposit(
 	amountStr string,
 	toDeposit insolar.Reference,
 	fromMember insolar.Reference,

--- a/application/builtin/contract/account/account.wrapper.go
+++ b/application/builtin/contract/account/account.wrapper.go
@@ -327,20 +327,20 @@ func INSMETHOD_IncreaseBalance(object []byte, data []byte) (newState []byte, res
 	return
 }
 
-func INSMETHOD_TransferToDeposit(object []byte, data []byte) (newState []byte, result []byte, err error) {
+func INSMETHOD_ReallocateToDeposit(object []byte, data []byte) (newState []byte, result []byte, err error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
 
 	self := new(Account)
 
 	if len(object) == 0 {
-		err = &foundation.Error{S: "[ FakeTransferToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Object is nil"}
+		err = &foundation.Error{S: "[ FakeReallocateToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Object is nil"}
 		return
 	}
 
 	err = ph.Deserialize(object, self)
 	if err != nil {
-		err = &foundation.Error{S: "[ FakeTransferToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Data: " + err.Error()}
+		err = &foundation.Error{S: "[ FakeReallocateToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Data: " + err.Error()}
 		return
 	}
 
@@ -356,7 +356,7 @@ func INSMETHOD_TransferToDeposit(object []byte, data []byte) (newState []byte, r
 
 	err = ph.Deserialize(data, &args)
 	if err != nil {
-		err = &foundation.Error{S: "[ FakeTransferToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		err = &foundation.Error{S: "[ FakeReallocateToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
 		return
 	}
 
@@ -392,7 +392,7 @@ func INSMETHOD_TransferToDeposit(object []byte, data []byte) (newState []byte, r
 		}
 	}()
 
-	ret0 = self.TransferToDeposit(args0, args1, args2, args3)
+	ret0 = self.ReallocateToDeposit(args0, args1, args2, args3)
 
 	needRecover = false
 
@@ -497,10 +497,10 @@ func INSCONSTRUCTOR_New(ref insolar.Reference, data []byte) (state []byte, resul
 func Initialize() insolar.ContractWrapper {
 	return insolar.ContractWrapper{
 		Methods: insolar.ContractMethods{
-			"GetBalance":        INSMETHOD_GetBalance,
-			"Transfer":          INSMETHOD_Transfer,
-			"IncreaseBalance":   INSMETHOD_IncreaseBalance,
-			"TransferToDeposit": INSMETHOD_TransferToDeposit,
+			"GetBalance":          INSMETHOD_GetBalance,
+			"Transfer":            INSMETHOD_Transfer,
+			"IncreaseBalance":     INSMETHOD_IncreaseBalance,
+			"ReallocateToDeposit": INSMETHOD_ReallocateToDeposit,
 
 			"GetCode":      INSMETHOD_GetCode,
 			"GetPrototype": INSMETHOD_GetPrototype,

--- a/application/builtin/contract/account/account.wrapper.go
+++ b/application/builtin/contract/account/account.wrapper.go
@@ -327,6 +327,94 @@ func INSMETHOD_IncreaseBalance(object []byte, data []byte) (newState []byte, res
 	return
 }
 
+func INSMETHOD_TransferToDeposit(object []byte, data []byte) (newState []byte, result []byte, err error) {
+	ph := common.CurrentProxyCtx
+	ph.SetSystemError(nil)
+
+	self := new(Account)
+
+	if len(object) == 0 {
+		err = &foundation.Error{S: "[ FakeTransferToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Object is nil"}
+		return
+	}
+
+	err = ph.Deserialize(object, self)
+	if err != nil {
+		err = &foundation.Error{S: "[ FakeTransferToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Data: " + err.Error()}
+		return
+	}
+
+	args := make([]interface{}, 4)
+	var args0 string
+	args[0] = &args0
+	var args1 insolar.Reference
+	args[1] = &args1
+	var args2 insolar.Reference
+	args[2] = &args2
+	var args3 insolar.Reference
+	args[3] = &args3
+
+	err = ph.Deserialize(data, &args)
+	if err != nil {
+		err = &foundation.Error{S: "[ FakeTransferToDeposit ] ( INSMETHOD_* ) ( Generated Method ) Can't deserialize args.Arguments: " + err.Error()}
+		return
+	}
+
+	var ret0 error
+
+	serializeResults := func() error {
+		return ph.Serialize(
+			foundation.Result{Returns: []interface{}{ret0}},
+			&result,
+		)
+	}
+
+	needRecover := true
+	defer func() {
+		if !needRecover {
+			return
+		}
+		if r := recover(); r != nil {
+			recoveredError := errors.Wrap(errors.Errorf("%v", r), "Failed to execute method (panic)")
+			recoveredError = ph.MakeErrorSerializable(recoveredError)
+
+			if PanicIsLogicalError {
+				ret0 = recoveredError
+
+				newState = object
+				err = serializeResults()
+				if err == nil {
+					newState = object
+				}
+			} else {
+				err = recoveredError
+			}
+		}
+	}()
+
+	ret0 = self.TransferToDeposit(args0, args1, args2, args3)
+
+	needRecover = false
+
+	if ph.GetSystemError() != nil {
+		return nil, nil, ph.GetSystemError()
+	}
+
+	err = ph.Serialize(self, &newState)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ret0 = ph.MakeErrorSerializable(ret0)
+
+	err = serializeResults()
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 func INSCONSTRUCTOR_New(ref insolar.Reference, data []byte) (state []byte, result []byte, err error) {
 	ph := common.CurrentProxyCtx
 	ph.SetSystemError(nil)
@@ -409,9 +497,10 @@ func INSCONSTRUCTOR_New(ref insolar.Reference, data []byte) (state []byte, resul
 func Initialize() insolar.ContractWrapper {
 	return insolar.ContractWrapper{
 		Methods: insolar.ContractMethods{
-			"GetBalance":      INSMETHOD_GetBalance,
-			"Transfer":        INSMETHOD_Transfer,
-			"IncreaseBalance": INSMETHOD_IncreaseBalance,
+			"GetBalance":        INSMETHOD_GetBalance,
+			"Transfer":          INSMETHOD_Transfer,
+			"IncreaseBalance":   INSMETHOD_IncreaseBalance,
+			"TransferToDeposit": INSMETHOD_TransferToDeposit,
 
 			"GetCode":      INSMETHOD_GetCode,
 			"GetPrototype": INSMETHOD_GetPrototype,

--- a/application/builtin/contract/member/member.go
+++ b/application/builtin/contract/member/member.go
@@ -417,7 +417,7 @@ func (m *Member) accountTransferToDepositCall(params map[string]interface{}) (in
 	}
 	acc := account.GetObject(*accountRef)
 
-	return nil, acc.TransferToDeposit(amountStr, *toDepositRef, m.GetReference(), *request)
+	return nil, acc.ReallocateToDeposit(amountStr, *toDepositRef, m.GetReference(), *request)
 }
 
 // Platform methods.

--- a/application/builtin/proxy/account/account.go
+++ b/application/builtin/proxy/account/account.go
@@ -390,8 +390,8 @@ func (r *Account) IncreaseBalanceAsImmutable(amountStr string) error {
 	return nil
 }
 
-// TransferToDeposit is proxy generated method
-func (r *Account) TransferToDeposit(amountStr string, toDeposit insolar.Reference, fromMember insolar.Reference, request insolar.Reference) error {
+// ReallocateToDeposit is proxy generated method
+func (r *Account) ReallocateToDeposit(amountStr string, toDeposit insolar.Reference, fromMember insolar.Reference, request insolar.Reference) error {
 	var args [4]interface{}
 	args[0] = amountStr
 	args[1] = toDeposit
@@ -409,7 +409,7 @@ func (r *Account) TransferToDeposit(amountStr string, toDeposit insolar.Referenc
 		return err
 	}
 
-	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, false, false, "TransferToDeposit", argsSerialized, *PrototypeReference)
+	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, false, false, "ReallocateToDeposit", argsSerialized, *PrototypeReference)
 	if err != nil {
 		return err
 	}
@@ -431,8 +431,8 @@ func (r *Account) TransferToDeposit(amountStr string, toDeposit insolar.Referenc
 	return nil
 }
 
-// TransferToDepositAsImmutable is proxy generated method
-func (r *Account) TransferToDepositAsImmutable(amountStr string, toDeposit insolar.Reference, fromMember insolar.Reference, request insolar.Reference) error {
+// ReallocateToDepositAsImmutable is proxy generated method
+func (r *Account) ReallocateToDepositAsImmutable(amountStr string, toDeposit insolar.Reference, fromMember insolar.Reference, request insolar.Reference) error {
 	var args [4]interface{}
 	args[0] = amountStr
 	args[1] = toDeposit
@@ -450,7 +450,7 @@ func (r *Account) TransferToDepositAsImmutable(amountStr string, toDeposit insol
 		return err
 	}
 
-	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, true, false, "TransferToDeposit", argsSerialized, *PrototypeReference)
+	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, true, false, "ReallocateToDeposit", argsSerialized, *PrototypeReference)
 	if err != nil {
 		return err
 	}

--- a/application/builtin/proxy/account/account.go
+++ b/application/builtin/proxy/account/account.go
@@ -389,3 +389,85 @@ func (r *Account) IncreaseBalanceAsImmutable(amountStr string) error {
 	}
 	return nil
 }
+
+// TransferToDeposit is proxy generated method
+func (r *Account) TransferToDeposit(amountStr string, toDeposit insolar.Reference, fromMember insolar.Reference, request insolar.Reference) error {
+	var args [4]interface{}
+	args[0] = amountStr
+	args[1] = toDeposit
+	args[2] = fromMember
+	args[3] = request
+
+	var argsSerialized []byte
+
+	ret := make([]interface{}, 1)
+	var ret0 *foundation.Error
+	ret[0] = &ret0
+
+	err := common.CurrentProxyCtx.Serialize(args, &argsSerialized)
+	if err != nil {
+		return err
+	}
+
+	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, false, false, "TransferToDeposit", argsSerialized, *PrototypeReference)
+	if err != nil {
+		return err
+	}
+
+	resultContainer := foundation.Result{
+		Returns: ret,
+	}
+	err = common.CurrentProxyCtx.Deserialize(res, &resultContainer)
+	if err != nil {
+		return err
+	}
+	if resultContainer.Error != nil {
+		err = resultContainer.Error
+		return err
+	}
+	if ret0 != nil {
+		return ret0
+	}
+	return nil
+}
+
+// TransferToDepositAsImmutable is proxy generated method
+func (r *Account) TransferToDepositAsImmutable(amountStr string, toDeposit insolar.Reference, fromMember insolar.Reference, request insolar.Reference) error {
+	var args [4]interface{}
+	args[0] = amountStr
+	args[1] = toDeposit
+	args[2] = fromMember
+	args[3] = request
+
+	var argsSerialized []byte
+
+	ret := make([]interface{}, 1)
+	var ret0 *foundation.Error
+	ret[0] = &ret0
+
+	err := common.CurrentProxyCtx.Serialize(args, &argsSerialized)
+	if err != nil {
+		return err
+	}
+
+	res, err := common.CurrentProxyCtx.RouteCall(r.Reference, true, false, "TransferToDeposit", argsSerialized, *PrototypeReference)
+	if err != nil {
+		return err
+	}
+
+	resultContainer := foundation.Result{
+		Returns: ret,
+	}
+	err = common.CurrentProxyCtx.Deserialize(res, &resultContainer)
+	if err != nil {
+		return err
+	}
+	if resultContainer.Error != nil {
+		err = resultContainer.Error
+		return err
+	}
+	if ret0 != nil {
+		return ret0
+	}
+	return nil
+}

--- a/application/functest/account_transfer_to_deposit_test.go
+++ b/application/functest/account_transfer_to_deposit_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Insolar Network Ltd.
+// All rights reserved.
+// This material is licensed under the Insolar License version 1.0,
+// available at https://github.com/insolar/mainnet/blob/master/LICENSE.md.
+
+// +build functest
+
+package functest
+
+import (
+	"testing"
+
+	"github.com/insolar/insolar/applicationbase/testutils/launchnet"
+	"github.com/insolar/insolar/applicationbase/testutils/testrequest"
+	"github.com/insolar/insolar/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountTransferToDeposit(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		ethHash := testutils.RandomEthHash()
+
+		firstMember := createMember(t)
+		secondMember := fullMigration(t, ethHash)
+
+		// init money on member
+		_, err := testrequest.SignedRequest(t, launchnet.TestRPCUrlPublic, &Root, "member.transfer",
+			map[string]interface{}{"amount": "2000000000", "toMemberReference": firstMember.Ref})
+		require.NoError(t, err)
+
+		_, err = testrequest.SignedRequest(t, launchnet.TestRPCUrl, firstMember,
+			"account.transferToDeposit", map[string]interface{}{"amount": "1000", "toDepositName": ethHash, "toMemberReference": secondMember.GetReference()})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("NotEnoughBalance", func(t *testing.T) {
+		ethHash := testutils.RandomEthHash()
+
+		member := createMember(t)
+		member2 := fullMigration(t, ethHash)
+
+		_, err := testrequest.SignedRequestWithEmptyRequestRef(t, launchnet.TestRPCUrl, member,
+			"account.transferToDeposit", map[string]interface{}{"amount": "1000", "toDepositName": ethHash, "toMemberReference": member2.GetReference()})
+		data := checkConvertRequesterError(t, err).Data
+		require.Contains(t, data.Trace, "not enough balance for transfer")
+	})
+}

--- a/application/functest/test_utils.go
+++ b/application/functest/test_utils.go
@@ -106,6 +106,19 @@ func getAdminDepositBalance(t *testing.T, caller *AppUser, reference string) (*b
 	return amount, nil
 }
 
+func getDepositBalance(t *testing.T, caller *AppUser, reference string, ethHash string) (*big.Int, error) {
+	_, deposits := getBalanceAndDepositsNoErr(t, caller, reference)
+	mapd, ok := deposits[ethHash].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("can't parse deposit")
+	}
+	amount, ok := new(big.Int).SetString(mapd["balance"].(string), 10)
+	if !ok {
+		return nil, fmt.Errorf("can't parse deposit balance")
+	}
+	return amount, nil
+}
+
 func getBalanceAndDepositsNoErr(t *testing.T, caller *AppUser, reference string) (*big.Int, map[string]interface{}) {
 	balance, deposits, err := getBalanceAndDeposits(t, caller, reference)
 	require.NoError(t, err)

--- a/cmd/insolard/api.go
+++ b/cmd/insolard/api.go
@@ -65,6 +65,7 @@ func initAPIOptions() (api.Options, error) {
 		"deposit.migration":          true,
 		"deposit.createFund":         true,
 		"member.getBalance":          true,
+		"account.transferToDeposit":  true,
 	}
 	contractMethods := map[string]bool{
 		"member.create":          true,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
implemented `account.transferToDeposit` method
**- How I did it**
- added `account.ReallocateToDeposit` method that subtracts balance and calls saga `deposit.Accept`
- added corresponding switch case to Member contract and private method to call `account.ReallocateToDeposit`

**- How to verify it**
run `TestAccountTransferToDeposit`
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
