### PR TITLE
MN-662: fix TestMigrationDaemonTransferDeposit

### DIFF
--- a/application/builtin/contract/deposit/deposit.go
+++ b/application/builtin/contract/deposit/deposit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/insolar/insolar/insolar"
 	"github.com/insolar/insolar/logicrunner/builtin/foundation"
 	"github.com/insolar/insolar/logicrunner/builtin/foundation/safemath"
+
 	"github.com/insolar/mainnet/application/appfoundation"
 	"github.com/insolar/mainnet/application/builtin/proxy/deposit"
 	"github.com/insolar/mainnet/application/builtin/proxy/member"
@@ -315,11 +316,11 @@ func (d *Deposit) availableAmount() (*big.Int, error) {
 
 	amount, ok := new(big.Int).SetString(d.Amount, 10)
 	if !ok {
-		return nil, errors.New("can't parse derposit amount")
+		return nil, errors.New("can't parse deposit amount")
 	}
 	balance, ok := new(big.Int).SetString(d.Balance, 10)
 	if !ok {
-		return nil, errors.New("can't parse derposit balance")
+		return nil, errors.New("can't parse deposit balance")
 	}
 
 	// Allow to transfer whole balance if vesting period has already finished

--- a/cmd/insolard/genesisstate/genesis.go
+++ b/cmd/insolard/genesisstate/genesis.go
@@ -3,7 +3,7 @@
 // This material is licensed under the Insolar License version 1.0,
 // available at https://github.com/insolar/mainnet/blob/master/LICENSE.md.
 
-package main
+package genesisstate
 
 import (
 	"encoding/json"
@@ -44,7 +44,7 @@ const (
 	FoundationVestingStep     = 0
 )
 
-func initStates(genesisConfigPath string) ([]genesis.ContractState, error) {
+func InitStates(genesisConfigPath string) ([]genesis.ContractState, error) {
 	b, err := ioutil.ReadFile(genesisConfigPath)
 	if err != nil {
 		log.Fatalf("failed to load genesis configuration from file: %v", genesisConfigPath)

--- a/cmd/insolard/main.go
+++ b/cmd/insolard/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/insolar/mainnet/application"
 	appbuiltin "github.com/insolar/mainnet/application/builtin"
+	"github.com/insolar/mainnet/cmd/insolard/genesisstate"
 )
 
 func main() {
@@ -114,7 +115,7 @@ func runHeavyNode(configPath string, genesisConfigPath string, db string, genesi
 		log.Fatal(errors.Wrap(err, "failed to get API info response"))
 	}
 
-	states, _ := initStates(genesisConfigPath)
+	states, _ := genesisstate.InitStates(genesisConfigPath)
 	s := server.NewHeavyServer(
 		holder,
 		genesisConfigPath,


### PR DESCRIPTION
**- What I did**
I have moved genesis.go from the main package to the genesisstate package.
I have imported constant from genesisstate package and use it to split the logic of the test. Depend on the constant the test should behave differently.

**- How to verify it**
run `make test_func`