### PR TITLE
MN-583: add double deposit creation check

### DIFF
--- a/application/builtin/contract/member/member.go
+++ b/application/builtin/contract/member/member.go
@@ -461,6 +461,13 @@ func (m *Member) depositCreateCall(params map[string]interface{}) (interface{}, 
 		ZeroBalance    = "0"
 		FullyConfirmed = true
 	)
+	found, _, err = targetWalletObj.FindDeposit(newTxHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check existence of linear deposit")
+	}
+	if found {
+		return nil, errors.New("linear deposit is already created")
+	}
 	newDeposit, err := targetWalletObj.FindOrCreateDeposit(newTxHash, vestingParams.Lockup, vestingParams.Vesting, vestingParams.VestingStep, ZeroBalance, pulseDepositUnHold, depositInfo.MigrationDaemonConfirms, depositInfo.Amount, appfoundation.LinearVesting, FullyConfirmed)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find or create deposit")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added additional check to prevent double creation when called deposit.create
**- How I did it**
Added call wallet.FindDeposit with `#{txHash}_2`
**- How to verify it**
Run func tests
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
