### PR TITLE
NOISSUE: clarify deposit.Confirm

### DIFF
--- a/application/builtin/contract/deposit/deposit.go
+++ b/application/builtin/contract/deposit/deposit.go
@@ -198,7 +198,7 @@ func (d *Deposit) Confirm(txHash string, proposedAmount string, migrationDaemonR
 	if len(d.MigrationDaemonConfirms) < numConfirmation {
 		return nil
 	}
-	amounts := d.toAmounts(d.MigrationDaemonConfirms)
+	amounts := d.amounts()
 	if !d.allAmountsEqual(amounts) {
 		return fmt.Errorf("some of confirmation amounts aren't equal others confirms=%v",
 			d.MigrationDaemonConfirms)
@@ -259,9 +259,9 @@ func (d *Deposit) TransferToDeposit(
 
 }
 
-func (d *Deposit) toAmounts(confirms map[string]string) []string {
+func (d *Deposit) amounts() []string {
 	var amounts []string
-	for _, amount := range confirms {
+	for _, amount := range d.MigrationDaemonConfirms {
 		amounts = append(amounts, amount)
 	}
 	return amounts

--- a/application/builtin/proxy/deposit/deposit.go
+++ b/application/builtin/proxy/deposit/deposit.go
@@ -502,12 +502,12 @@ func (r *Deposit) Itself() (interface{}, error) {
 }
 
 // Confirm is proxy generated method
-func (r *Deposit) Confirm(txHash string, amountStr string, fromMember insolar.Reference, request insolar.Reference, toMember insolar.Reference) error {
+func (r *Deposit) Confirm(txHash string, proposedAmount string, migrationDaemonRef insolar.Reference, requestRef insolar.Reference, toMember insolar.Reference) error {
 	var args [5]interface{}
 	args[0] = txHash
-	args[1] = amountStr
-	args[2] = fromMember
-	args[3] = request
+	args[1] = proposedAmount
+	args[2] = migrationDaemonRef
+	args[3] = requestRef
 	args[4] = toMember
 
 	var argsSerialized []byte
@@ -544,12 +544,12 @@ func (r *Deposit) Confirm(txHash string, amountStr string, fromMember insolar.Re
 }
 
 // ConfirmAsImmutable is proxy generated method
-func (r *Deposit) ConfirmAsImmutable(txHash string, amountStr string, fromMember insolar.Reference, request insolar.Reference, toMember insolar.Reference) error {
+func (r *Deposit) ConfirmAsImmutable(txHash string, proposedAmount string, migrationDaemonRef insolar.Reference, requestRef insolar.Reference, toMember insolar.Reference) error {
 	var args [5]interface{}
 	args[0] = txHash
-	args[1] = amountStr
-	args[2] = fromMember
-	args[3] = request
+	args[1] = proposedAmount
+	args[2] = migrationDaemonRef
+	args[3] = requestRef
 	args[4] = toMember
 
 	var argsSerialized []byte

--- a/application/functest/deposit_migration_test.go
+++ b/application/functest/deposit_migration_test.go
@@ -10,6 +10,7 @@ package functest
 import (
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"testing"
 
@@ -230,12 +231,13 @@ func TestMigrationAnotherAmountSameTx(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "30", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "failed to check amount in confirmation from migration daemon")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 200", MigrationDaemons[0].Ref))
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 300", MigrationDaemons[2].Ref))
+	trace := strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:200", MigrationDaemons[0].Ref))
+	require.Contains(t, trace, fmt.Sprintf("%s:300", MigrationDaemons[2].Ref))
 }
 
-func TestMigration_WrongSecondAMount(t *testing.T) {
+func TestMigration_WrongSecondAmount(t *testing.T) {
 	activateDaemons(t, countThreeActiveDaemon)
 
 	member := createMigrationMemberForMA(t)
@@ -254,9 +256,10 @@ func TestMigration_WrongSecondAMount(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "200", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "several migration daemons send different amount")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 1000", MigrationDaemons[0].Ref))
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 2000", MigrationDaemons[1].Ref))
+	trace := strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:1000", MigrationDaemons[0].Ref))
+	require.Contains(t, trace, fmt.Sprintf("%s:2000", MigrationDaemons[1].Ref))
 
 	_, _, err = testrequest.MakeSignedRequest(
 		launchnet.TestRPCUrl,
@@ -264,16 +267,17 @@ func TestMigration_WrongSecondAMount(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "100", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data = checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "several migration daemons send different amount")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 2000", MigrationDaemons[1].Ref))
+	trace = strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:2000", MigrationDaemons[1].Ref))
 
 	_, deposits := getBalanceAndDepositsNoErr(t, member, member.Ref)
 	deposit, ok := deposits[ethHash].(map[string]interface{})
 	require.True(t, ok)
 	require.Equal(t, ethHash, deposit["ethTxHash"])
-	require.Equal(t, "1000", deposit["amount"])
+	require.Equal(t, "0", deposit["amount"])
 	memberBalance := deposit["balance"].(string)
-	require.Equal(t, "1000", memberBalance)
+	require.Equal(t, "0", memberBalance)
 	confirmations := deposit["confirmerReferences"].(map[string]interface{})
 	require.Equal(t, "1000", confirmations[MigrationDaemons[0].Ref])
 	require.Equal(t, "2000", confirmations[MigrationDaemons[1].Ref])
@@ -299,9 +303,10 @@ func TestMigration_WrongFirstAmount(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "100", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "several migration daemons send different amount")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 2000", MigrationDaemons[0].Ref))
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 1000", MigrationDaemons[1].Ref))
+	trace := strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:2000", MigrationDaemons[0].Ref))
+	require.Contains(t, trace, fmt.Sprintf("%s:1000", MigrationDaemons[1].Ref))
 
 	_, _, err = testrequest.MakeSignedRequest(
 		launchnet.TestRPCUrl,
@@ -309,16 +314,17 @@ func TestMigration_WrongFirstAmount(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "100", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data = checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "several migration daemons send different amount")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 2000", MigrationDaemons[0].Ref))
+	trace = strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:2000", MigrationDaemons[0].Ref))
 
 	_, deposits := getBalanceAndDepositsNoErr(t, member, member.Ref)
 	deposit, ok := deposits[ethHash].(map[string]interface{})
 	require.True(t, ok)
 	require.Equal(t, ethHash, deposit["ethTxHash"])
-	require.Equal(t, "1000", deposit["amount"])
+	require.Equal(t, "0", deposit["amount"])
 	memberBalance := deposit["balance"].(string)
-	require.Equal(t, "1000", memberBalance)
+	require.Equal(t, "0", memberBalance)
 	confirmations := deposit["confirmerReferences"].(map[string]interface{})
 	require.Equal(t, "2000", confirmations[MigrationDaemons[0].Ref])
 	require.Equal(t, "1000", confirmations[MigrationDaemons[1].Ref])
@@ -384,9 +390,10 @@ func TestMigration_WrongAllAmount(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "200", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data := checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "several migration daemons send different amount")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 1000", MigrationDaemons[0].Ref))
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 2000", MigrationDaemons[1].Ref))
+	trace := strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:1000", MigrationDaemons[0].Ref))
+	require.Contains(t, trace, fmt.Sprintf("%s:2000", MigrationDaemons[1].Ref))
 
 	_, _, err = testrequest.MakeSignedRequest(
 		launchnet.TestRPCUrl,
@@ -394,10 +401,11 @@ func TestMigration_WrongAllAmount(t *testing.T) {
 		"deposit.migration",
 		map[string]interface{}{"amount": "300", "ethTxHash": ethHash, "migrationAddress": member.MigrationAddress})
 	data = checkConvertRequesterError(t, err).Data
-	require.Contains(t, data.Trace, "several migration daemons send different amount")
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 1000", MigrationDaemons[0].Ref))
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 2000", MigrationDaemons[1].Ref))
-	require.Contains(t, data.Trace, fmt.Sprintf("%s send amount 3000", MigrationDaemons[2].Ref))
+	trace = strings.Join(data.Trace, ": ")
+	require.Contains(t, trace, "some of confirmation amounts aren't equal others")
+	require.Contains(t, trace, fmt.Sprintf("%s:1000", MigrationDaemons[0].Ref))
+	require.Contains(t, trace, fmt.Sprintf("%s:2000", MigrationDaemons[1].Ref))
+	require.Contains(t, trace, fmt.Sprintf("%s:3000", MigrationDaemons[2].Ref))
 
 	_, deposits := getBalanceAndDepositsNoErr(t, member, member.Ref)
 	deposit, ok := deposits[ethHash].(map[string]interface{})

--- a/application/functest/test_utils.go
+++ b/application/functest/test_utils.go
@@ -53,6 +53,7 @@ type rpcInfoResponse struct {
 }
 
 func checkConvertRequesterError(t *testing.T, err error) *requester.Error {
+	require.Error(t, err)
 	rv, ok := err.(*requester.Error)
 	require.Truef(t, ok, "got wrong error %T (expected *requester.Error) with text '%s'", err, err.Error())
 	return rv


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Clarified method `deposit.Confirm`

**- Why?**
Because the logic was confusing and makes it very difficult to further expand the functionality (we need to expand within the task [MN-588](https://insolar.atlassian.net/browse/MN-588)), and also increases the risk of making new errors.

**- How I did it**

- Eliminated excessive checks about daemon activation
- Simplified amount's comparison
- The transfer of the assets extracted to a new method `deposit.acquireFundAssets`
- Checking amounts is made more rigorous (now all amounts must be equal)

**- How to verify it**
Run func tests
