### PR TITLE
MN-588: update migration procedure

### DIFF
--- a/application/functest/deposit_create_test.go
+++ b/application/functest/deposit_create_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestDepositCreate(t *testing.T) {
 	t.Run("happy_path", func(t *testing.T) {
+		t.Skip("skipped. due to the lack of test users with old migration type")
 		ethHash := testutils.RandomEthHash()
 		targetMember := fullMigration(t, ethHash)
 		targetDeposit := getDepositReference(t, targetMember, ethHash)

--- a/application/functest/deposit_create_test.go
+++ b/application/functest/deposit_create_test.go
@@ -20,8 +20,9 @@ import (
 )
 
 func TestDepositCreate(t *testing.T) {
+	t.Skip("skipped. due to the lack of test users with old migration type")
+
 	t.Run("happy_path", func(t *testing.T) {
-		t.Skip("skipped. due to the lack of test users with old migration type")
 		ethHash := testutils.RandomEthHash()
 		targetMember := fullMigration(t, ethHash)
 		targetDeposit := getDepositReference(t, targetMember, ethHash)

--- a/application/functest/launchnet.go
+++ b/application/functest/launchnet.go
@@ -9,17 +9,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"strconv"
 	"time"
 
 	"github.com/insolar/insolar/insolar/defaults"
-	"github.com/insolar/insolar/testutils"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/pkg/errors"
 
 	"github.com/insolar/insolar/applicationbase/testutils/launchnet"
+
 	"github.com/insolar/mainnet/application"
 	"github.com/insolar/mainnet/application/builtin/contract/deposit"
 	"github.com/insolar/mainnet/application/genesisrefs"
@@ -243,74 +242,60 @@ func preparePublicAllocation2() error {
 	}
 
 	migrationAdmin := insSDK.GetMigrationAdminMember()
-	fundAmount, err := getFundBalance(insSDK, migrationAdmin, genesisrefs.FundsDepositName)
-	if err != nil {
-		return errors.Wrap(err, "failed to get deposit balance")
+
+	for i, donor := range insSDK.GetEnterpriseMembers() {
+		err := transferFromAccountToDeposit(
+			insSDK,
+			donor,
+			deposit.PublicAllocation2DepositName,
+			migrationAdmin.GetReference(),
+			application.EnterpriseDistributionAmount,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to transfer money from enterprise member #%d", i)
+		}
 	}
-	halfAmount := fundAmount.Div(fundAmount, big.NewInt(2))
-	donorUser, donorDeposit, err := prepareFundDonor(insSDK, halfAmount)
-	if err != nil {
-		return errors.Wrap(err, "failed to prepare fund donor")
+
+	for i, donor := range insSDK.GetApplicationIncentivesMembers() {
+		err = transferFromDepositToDeposit(
+			insSDK,
+			donor,
+			genesisrefs.FundsDepositName,
+			deposit.PublicAllocation2DepositName,
+			migrationAdmin.GetReference(),
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to transfer money from application incentives member #%d", i)
+		}
 	}
-	err = transferFromDepositToDeposit(
-		insSDK,
-		donorUser,
-		donorDeposit,
-		deposit.PublicAllocation2DepositName,
-		migrationAdmin.GetReference(),
-	)
-	if err != nil {
-		return errors.Wrap(err, "failed to transfer money from donor member")
+
+	for i, donor := range insSDK.GetFoundationMembers() {
+		err = transferFromDepositToDeposit(
+			insSDK,
+			donor,
+			genesisrefs.FundsDepositName,
+			deposit.PublicAllocation2DepositName,
+			migrationAdmin.GetReference(),
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to transfer money from foundation member #%d", i)
+		}
 	}
+
+	for i, donor := range insSDK.GetNetworkIncentivesMembers() {
+		err = transferFromDepositToDeposit(
+			insSDK,
+			donor,
+			genesisrefs.FundsDepositName,
+			deposit.PublicAllocation2DepositName,
+			migrationAdmin.GetReference(),
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to transfer money from network incentives member #%d", i)
+		}
+	}
+
 	return nil
-}
-
-func getFundBalance(insSDK *sdk.SDK, migrationAdmin sdk.Member, ethHash string) (*big.Int, error) {
-	_, deposits, err := insSDK.GetBalance(migrationAdmin)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to call member.getBalance")
-	}
-
-	for _, d := range deposits {
-		depositJson, err := json.Marshal(d)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal deposit info map")
-		}
-		depositInfo := &deposit.DepositOut{}
-		err = json.Unmarshal(depositJson, depositInfo)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal deposit info")
-		}
-
-		if depositInfo.TxHash == ethHash {
-			balance, ok := new(big.Int).SetString(depositInfo.Balance, 10)
-			if !ok {
-				return nil, errors.New("can't parse deposit balance")
-			}
-			return balance, nil
-		}
-	}
-	return nil, errors.New("failed to find deposit")
-}
-
-func prepareFundDonor(insSDK *sdk.SDK, fundAmount *big.Int) (sdk.Member, string, error) {
-	ethHash := testutils.RandomEthHash()
-	amountForMigration := new(big.Int).Div(fundAmount, big.NewInt(10))
-
-	daemons, err := insSDK.GetAndActivateMigrationDaemonMembers()
-	if err != nil {
-		return nil, "", errors.Wrap(err, "failed to get or activate migration daemon members")
-	}
-	donorMember, _, err := insSDK.MigrationCreateMember()
-	if err != nil {
-		return nil, "", errors.Wrap(err, "failed to create fund donor member")
-	}
-	migrationMember := donorMember.(*sdk.MigrationMember)
-	_, err = insSDK.FullMigration(daemons, ethHash, amountForMigration.String(), migrationMember.MigrationAddress)
-	if err != nil {
-		return nil, "", errors.Wrap(err, "failed to migrate donor member")
-	}
-	return donorMember, ethHash, nil
 }
 
 func transferFromDepositToDeposit(insSDK *sdk.SDK,
@@ -322,6 +307,20 @@ func transferFromDepositToDeposit(insSDK *sdk.SDK,
 	_, err := insSDK.TransferFromDepositToDeposit(from, fromDepositName, toDepositName, toMemberRef)
 	if err != nil {
 		return errors.Wrap(err, "failed to call deposit.transferToDeposit")
+	}
+	return nil
+}
+
+func transferFromAccountToDeposit(insSDK *sdk.SDK,
+	from sdk.Member,
+	toDepositName string,
+	toMemberRef string,
+	amount string,
+) error {
+
+	_, err := insSDK.TransferFromAccountToDeposit(from, toDepositName, toMemberRef, amount)
+	if err != nil {
+		return errors.Wrap(err, "failed to call account.transferToDeposit")
 	}
 	return nil
 }

--- a/application/functest/test_utils.go
+++ b/application/functest/test_utils.go
@@ -381,7 +381,7 @@ func verifyFundsMembersAndDeposits(t *testing.T, m *AppUser, expectedAmount, exp
 	}
 	deposit, ok := deposits["genesis_deposit"].(map[string]interface{})
 	if deposit["amount"] != expectedAmount {
-		return errors.New(fmt.Sprintf("deposit amount should be %s, current value: %s", expectedBalance, deposit["amount"]))
+		return errors.New(fmt.Sprintf("deposit amount should be %s, current value: %s", expectedAmount, deposit["amount"]))
 	}
 	if deposit["balance"] != expectedBalance {
 		return errors.New(fmt.Sprintf("deposit balance should be %s, current value: %s", expectedBalance, deposit["balance"]))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Injected linear deposit creation into migration procedure
**- How I did it**

- Added `deposit.createAdditionalDeposit` method that creates linear deposit
- Added call of `createAdditionalDeposit` when enough confirmations have been collected
- Added corresponding test changes to `TestDepositMigration` test to check that additional deposit created and created from "Public Allocation 2" fund
- Skipped `TestDepositCreate` test because it becomes impossible to create test users of the old type (with only one deposit)
- Made changes in `sdk.go` and `launchnet.go` to simulate actual fund reallocation
- And finally made changes in `fund_test.go` according to fund reallocation

**- How to verify it**
Run func tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
