### PR TITLE
MN-751: fill linear vesting params from default vesting params config

### DIFF
--- a/application/builtin/contract/migrationadmin/migrationadmin.go
+++ b/application/builtin/contract/migrationadmin/migrationadmin.go
@@ -25,6 +25,7 @@ type MigrationAdmin struct {
 	MigrationAdminMember   insolar.Reference
 	MigrationAddressShards []insolar.Reference
 	VestingParams          *VestingParams
+	LinearVestingParams    *VestingParams
 }
 
 type VestingParams struct {
@@ -215,6 +216,9 @@ func (mA *MigrationAdmin) GetDepositParameters() (*VestingParams, error) {
 
 // GetLinearDepositParameters returns hardcoded deposit parameters to make supplementary migration deposit for regular users.
 func (mA *MigrationAdmin) GetLinearDepositParameters() (*VestingParams, error) {
+	if mA.LinearVestingParams != nil {
+		return mA.LinearVestingParams, nil
+	}
 	return &VestingParams{
 		Lockup:      3 * 365 * 24 * 60 * 60, // three years
 		Vesting:     182 * 24 * 60 * 60,     // half a year

--- a/application/genesisrefs/contracts/contracts.go
+++ b/application/genesisrefs/contracts/contracts.go
@@ -140,7 +140,12 @@ func GetMigrationShardGenesisContractState(name string, migrationAddresses []str
 	}
 }
 
-func GetMigrationAdminGenesisContractState(lockup int64, vesting int64, vestingStep int64, maShardCount int) genesis.ContractState {
+func GetMigrationAdminGenesisContractState(
+	lockup int64,
+	vesting int64,
+	vestingStep int64,
+	maShardCount int,
+) genesis.ContractState {
 	return genesis.ContractState{
 		Name:       application.GenesisNameMigrationAdmin,
 		Prototype:  application.GenesisNameMigrationAdmin,
@@ -149,6 +154,11 @@ func GetMigrationAdminGenesisContractState(lockup int64, vesting int64, vestingS
 			MigrationAddressShards: genesisrefs.ContractMigrationAddressShards(maShardCount),
 			MigrationAdminMember:   genesisrefs.ContractMigrationAdminMember,
 			VestingParams: &migrationadmin.VestingParams{
+				Lockup:      lockup,
+				Vesting:     vesting,
+				VestingStep: vestingStep,
+			},
+			LinearVestingParams: &migrationadmin.VestingParams{
 				Lockup:      lockup,
 				Vesting:     vesting,
 				VestingStep: vestingStep,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Filled linear vesting params from default vesting params (from bootstap.yaml)
**- How I did it**

- Changed `GetMigrationAdminGenesisContractState` function
- Added condition to use params from MidrationAdmin contract state when them are not nil

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
